### PR TITLE
Mark beberlei/assert 3.3+ as conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
     "wyrihaximus/coding-standard": "^2.2.0",
     "wyrihaximus/phpstan-rules-wrapper": "^1.2.2"
   },
+  "conflict": {
+    "beberlei/assert": ">= 3.3"
+  },
   "config": {
     "platform": {
       "php": "7.4.7"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b484f951b5708694cea181dba0812172",
+    "content-hash": "3fe8b56cbc471530e6c52449cc17a569",
     "packages": [
         {
             "name": "amphp/amp",


### PR DESCRIPTION
For some reason beberlei/assert requires ext-intl, which isn't available
 in the Docker images we're using. So marking it as conflict for now