### PR TITLE
Restore the Dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     labels:
       - "Dependabot 🤖"
     versioning-strategy: "increase"
+    open-pull-requests-limit: 1
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This effectively reverts #360. Restoring the limit because of the useless amount of CI run this causes if Dependabot has several PR's open and it has to rebase due to another PR getting merged.