### PR TITLE
Updated composer lock file after running composer normalize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,10 +63,12 @@
   },
   "scripts": {
     "post-install-cmd": [
-      "composer normalize"
+      "composer normalize",
+      "composer update --lock --no-scripts"
     ],
     "post-update-cmd": [
-      "composer normalize"
+      "composer normalize",
+      "composer update --lock --no-scripts"
     ]
   }
 }


### PR DESCRIPTION
Sometimes the normalize changes the part composer hashes for the lockfile hash and results in failures on the CI which expect the lockfile to be update to date with composer.json. By updating the lockfile after running normalize that doesn't happen anymore.