### PR TITLE
Raise infection timeout

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,5 +1,5 @@
 {
-    "timeout": 120,
+    "timeout": 1800,
     "source": {
         "directories": [
             "src"


### PR DESCRIPTION
By raising this timeout we'll avoid false positives that take a very long time to run