### PR TITLE
Toggle PHPUnit flag displayDetailsOnTestsThatTriggerWarnings to true

### DIFF
--- a/etc/qa/phpunit.xml
+++ b/etc/qa/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" displayDetailsOnTestsThatTriggerWarnings="true">
   <testsuites>
     <testsuite name="Test Suite">
       <directory>../../tests/</directory>


### PR DESCRIPTION
This flag ensures instead of getting a Warning, PHPUnit will Fail the test and show the error PHP yielded.