### PR TITLE
Use local PHPUnit XSD instead of hitting the (inter)net(work)

### DIFF
--- a/etc/qa/phpunit.xml
+++ b/etc/qa/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory="../../var/phpunit/cache" displayDetailsOnTestsThatTriggerWarnings="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="../../vendor/phpunit/phpunit/phpunit.xsd" cacheDirectory="../../var/phpunit/cache" displayDetailsOnTestsThatTriggerWarnings="true">
   <testsuites>
     <testsuite name="Test Suite">
       <directory>../../tests/</directory>


### PR DESCRIPTION
When on an unstable connection, or with no internet at all, InfectionPHP will still try to validate the XML and error out as a result. By using the local XSD we always have the latest version locally.