### PR TITLE
Install make on-install-or-update || true on composer post install and update commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "wyrihaximus/test-utilities",
   "description": "\ud83d\udee0\ufe0f Test utilities for api-clients packages",
   "license": "MIT",
+  "type": "composer-plugin",
   "authors": [
     {
       "name": "Cees-Jan Kiewiet",
@@ -10,6 +11,9 @@
   ],
   "require": {
     "php": "^8.4",
+    "ext-hash": "^8.4",
+    "ext-json": "^8.4",
+    "composer-plugin-api": "^2",
     "ergebnis/composer-normalize": "^2.47.0",
     "ergebnis/phpunit-slow-test-detector": "^2.19.1",
     "icanhazstring/composer-unused": "^0.9.4",
@@ -31,7 +35,7 @@
   },
   "conflict": {
     "composer/pcre": "<3.3.2",
-    "wyrihaximus/makefiles": "<0.4.0"
+    "wyrihaximus/makefiles": "<0.5.0"
   },
   "suggest": {
     "wyrihaximus/async-test-utilities": "The recommended addition to this package when building ReactPHP packages and projects.",
@@ -64,6 +68,7 @@
     "sort-packages": true
   },
   "extra": {
+    "class": "WyriHaximus\\TestUtilities\\Composer\\Installer",
     "phpstan": {
       "includes": [
         "extension.neon"
@@ -75,6 +80,10 @@
       "make on-install-or-update || true"
     ],
     "post-update-cmd": [
+      "make on-install-or-update || true"
+    ],
+    "pre-autoload-dump": [
+      "WyriHaximus\\TestUtilities\\Composer\\Installer::findEventListeners",
       "make on-install-or-update || true"
     ]
   }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d9c1dd652f043bd568d113dbb0f5b16",
+    "content-hash": "0e1c695069fe2b1b315f39cde62d7458",
     "packages": [
         {
             "name": "azjezz/psl",
@@ -8671,7 +8671,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.4"
+        "php": "^8.4",
+        "ext-hash": "^8.4",
+        "ext-json": "^8.4",
+        "composer-plugin-api": "^2"
     },
     "platform-dev": {},
     "platform-overrides": {

--- a/etc/qa/composer-require-checker.json
+++ b/etc/qa/composer-require-checker.json
@@ -3,7 +3,10 @@
     "null", "true", "false",
     "static", "self", "parent",
     "array", "string", "int", "float", "bool", "iterable", "callable", "void", "object",
-    "Rector\\Configuration\\RectorConfigBuilder", "Rector\\Config\\RectorConfig"
+    "Rector\\Configuration\\RectorConfigBuilder", "Rector\\Config\\RectorConfig",
+    "Composer\\Composer", "Composer\\Config", "Composer\\EventDispatcher\\EventSubscriberInterface",
+    "Composer\\IO\\IOInterface", "Composer\\Package\\RootPackageInterface", "Composer\\Plugin\\PluginInterface",
+    "Composer\\Script\\Event", "Composer\\Script\\ScriptEvents", "JetBrains\\PHPStormStub\\PhpStormStubsMap"
   ],
   "php-core-extensions" : [
     "Core",

--- a/etc/qa/phpstan.neon
+++ b/etc/qa/phpstan.neon
@@ -10,6 +10,9 @@ parameters:
 		-
 			message: '#Error suppression via "@" should not be used.#'
 			path: ../../src/TestCase.php
+		-
+			message: '#Parameter \#1 \$scriptsSection of static method WyriHaximus\\TestUtilities\\Composer\\Installer::addMakeOnInstallOrUpdateToScriptsSectionAndRemoveCommandsItReplaces\(\) expects array<int, string>, mixed given.#'
+			path: ../../src/Composer/Installer.php
 
 includes:
 	- ../../extension.neon

--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WyriHaximus\TestUtilities\Composer;
+
+use Composer\Composer;
+use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+use Composer\Script\Event;
+use Composer\Script\ScriptEvents;
+use Exception;
+
+use function array_key_exists;
+use function array_keys;
+use function dirname;
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function hash;
+use function hash_equals;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function json_encode;
+use function preg_replace;
+
+use const DIRECTORY_SEPARATOR;
+use const JSON_PRETTY_PRINT;
+use const JSON_UNESCAPED_SLASHES;
+use const PHP_INT_MAX;
+
+final class Installer implements PluginInterface, EventSubscriberInterface
+{
+    /** @return array<string, array<string|int>> */
+    public static function getSubscribedEvents(): array
+    {
+        return [ScriptEvents::PRE_AUTOLOAD_DUMP => ['findEventListeners', PHP_INT_MAX]];
+    }
+
+    public function activate(Composer $composer, IOInterface $io): void
+    {
+        // does nothing, see getSubscribedEvents() instead.
+    }
+
+    public function deactivate(Composer $composer, IOInterface $io): void
+    {
+        // does nothing, see getSubscribedEvents() instead.
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io): void
+    {
+        // does nothing, see getSubscribedEvents() instead.
+    }
+
+    /**
+     * Called before every dump autoload, generates a fresh PHP class.
+     *
+     * @phpstan-ignore shipmonk.deadMethod
+     */
+    public static function findEventListeners(Event $event): void
+    {
+        $rootPackagePath = dirname(self::getVendorDir($event->getComposer())) . DIRECTORY_SEPARATOR;
+        if (! file_exists($rootPackagePath . '/composer.json')) {
+            return;
+        }
+
+        $jsonRaw = file_get_contents($rootPackagePath . '/composer.json');
+        if (! is_string($jsonRaw)) {
+            return;
+        }
+
+        $json = json_decode($jsonRaw, true);
+        if (! is_array($json)) {
+            return;
+        }
+
+        if (array_key_exists('name', $json) && $json['name'] === 'wyrihaximus/test-utilities') {
+            self::addMakeOnInstallOrUpdate($event->getIO(), $rootPackagePath);
+
+            return;
+        }
+
+        if (! array_key_exists('require-dev', $json)) {
+            return;
+        }
+
+        if (! is_array($json['require-dev'])) {
+            return;
+        }
+
+        foreach (array_keys($json['require-dev']) as $package) {
+            if ($package === 'wyrihaximus/test-utilities') {
+                self::addMakeOnInstallOrUpdate($event->getIO(), $rootPackagePath);
+
+                return;
+            }
+        }
+    }
+
+    private static function addMakeOnInstallOrUpdate(IOInterface $io, string $rootPackagePath): void
+    {
+        $io->write('<info>wyrihaximus/test-utilities:</info> Adding <fg=cyan>make on-install-or-update || true</> to scripts');
+        $composerJsonString = file_get_contents($rootPackagePath . '/composer.json');
+        if (! is_string($composerJsonString)) {
+            $io->write('<error>wyrihaximus/test-utilities:</error> Unable to read <fg=cyan>composer.json</> aborting');
+
+            return;
+        }
+
+        $composerJson     = json_decode($composerJsonString, true);
+        $composerJsonHash = hash('sha512', (string) json_encode($composerJson, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        if (is_array($composerJson) && array_key_exists('scripts', $composerJson) && is_array($composerJson['scripts'])) {
+            if (array_key_exists('post-install-cmd', $composerJson['scripts'])) {
+                $composerJson['scripts']['post-install-cmd'] = self::addMakeOnInstallOrUpdateToScriptsSectionAndRemoveCommandsItReplaces($composerJson['scripts']['post-install-cmd']);
+            }
+
+            if (array_key_exists('post-update-cmd', $composerJson['scripts'])) {
+                $composerJson['scripts']['post-update-cmd'] = self::addMakeOnInstallOrUpdateToScriptsSectionAndRemoveCommandsItReplaces($composerJson['scripts']['post-update-cmd']);
+            }
+        }
+
+        $replacementComposerJsonString = json_encode($composerJson, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (is_string($replacementComposerJsonString)) {
+            $replacementComposerJsonHash = hash('sha512', $replacementComposerJsonString);
+            if (! hash_equals($composerJsonHash, $replacementComposerJsonHash)) {
+                $replacementComposerJsonString = preg_replace('/^(  +?)\\1(?=[^ ])/m', '$1', $replacementComposerJsonString);
+                if (is_string($replacementComposerJsonString)) {
+                    $io->write('<info>wyrihaximus/test-utilities:</info> Writing new <fg=cyan>composer.json</>');
+                    file_put_contents($rootPackagePath . '/composer.json', $replacementComposerJsonString);
+                }
+            }
+        }
+
+        if (is_array($composerJson) && array_key_exists('scripts', $composerJson) && is_array($composerJson['scripts'])) {
+            if (array_key_exists('post-install-cmd', $composerJson['scripts'])) {
+                $composerJson['scripts']['post-install-cmd'] = self::addMakeOnInstallOrUpdateToScriptsSectionAndRemoveCommandsItReplaces($composerJson['scripts']['post-install-cmd']);
+            }
+
+            if (array_key_exists('post-update-cmd', $composerJson['scripts'])) {
+                $composerJson['scripts']['post-update-cmd'] = self::addMakeOnInstallOrUpdateToScriptsSectionAndRemoveCommandsItReplaces($composerJson['scripts']['post-update-cmd']);
+            }
+        }
+
+        $replacementComposerJsonString = json_encode($composerJson, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (is_string($replacementComposerJsonString)) {
+            $replacementComposerJsonHash = hash('sha512', $replacementComposerJsonString);
+            if (! hash_equals($composerJsonHash, $replacementComposerJsonHash)) {
+                $replacementComposerJsonString = preg_replace('/^(  +?)\\1(?=[^ ])/m', '$1', $replacementComposerJsonString);
+                if (is_string($replacementComposerJsonString)) {
+                    $io->write('<info>wyrihaximus/test-utilities:</info> Writing new <fg=cyan>composer.json</>');
+                    file_put_contents($rootPackagePath . '/composer.json', $replacementComposerJsonString);
+                }
+            }
+        }
+
+        $io->write('<info>wyrihaximus/test-utilities:</info> Finished <fg=cyan>make on-install-or-update || true</> to scripts');
+    }
+
+    /**
+     * @param array<int, string> $scriptsSection
+     *
+     * @return array<int, string>
+     */
+    private static function addMakeOnInstallOrUpdateToScriptsSectionAndRemoveCommandsItReplaces(array $scriptsSection): array
+    {
+        foreach ($scriptsSection as $script) {
+            if ($script === 'make on-install-or-update || true') {
+                return $scriptsSection;
+            }
+        }
+
+        $scripts = [];
+        foreach ($scriptsSection as $script) {
+            if ($script === 'composer normalize' || $script === 'composer update --lock --no-scripts') {
+                continue;
+            }
+
+            $scripts[] = $script;
+        }
+
+        $scripts[] = 'make on-install-or-update || true';
+
+        return $scripts;
+    }
+
+    /** @return non-empty-string */
+    private static function getVendorDir(Composer $composer): string
+    {
+        $vendorDir = $composer->getConfig()->get('vendor-dir');
+        if ($vendorDir === '' || ! file_exists($vendorDir)) {
+            throw new Exception('vendor-dir must be a string');
+        }
+
+        return $vendorDir;
+    }
+}


### PR DESCRIPTION
Turning this package into an extension so we can easily roll out `make on-install-or-update` to all packages.