### PR TITLE
RectorConfig only uses existing paths

### DIFF
--- a/src/RectorConfig.php
+++ b/src/RectorConfig.php
@@ -9,15 +9,15 @@ use Rector\Configuration\RectorConfigBuilder;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestFunctionPrefixWithAttributeRector;
 
+use function file_exists;
+
 final class RectorConfig
 {
     public static function configure(string $packageRootPath): RectorConfigBuilder
     {
         return Config\RectorConfig::configure()
             ->withPaths([
-                $packageRootPath . '/etc',
-                $packageRootPath . '/src',
-                $packageRootPath . '/tests',
+                ...self::getPaths($packageRootPath),
             ])
             ->withAttributesSets(all: true)
             ->withComposerBased(twig: true, doctrine: true, phpunit: true, symfony: true)
@@ -31,5 +31,23 @@ final class RectorConfig
             ])->withSkip([
                 RemoveExtraParametersRector::class,
             ]);
+    }
+
+    /** @return iterable<string> */
+    private static function getPaths(string $packageRootPath): iterable
+    {
+        foreach (
+            [
+                '/etc',
+                '/src',
+                '/tests',
+            ] as $path
+        ) {
+            if (! file_exists($packageRootPath . $path)) {
+                continue;
+            }
+
+            yield $packageRootPath . $path;
+        }
     }
 }


### PR DESCRIPTION
Not every package has a `tests` directory, so we shouldn't include it if it doesn't exists