### PR TITLE
Mark `sanmai` currently locked `di-container` and `pipeline` versions as safe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,8 @@
   "conflict": {
     "composer-unused/symbol-parser": "<0.3.3",
     "composer/pcre": "<3.3.2",
+    "sanmai/di-container": "<0.1.17",
+    "sanmai/pipeline": "<7.9",
     "wyrihaximus/makefiles": "<0.5.0"
   },
   "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9d4edce0b57e1c4b7ffeda70bed779b",
+    "content-hash": "2c301e223b6e0912683f71d57418389c",
     "packages": [
         {
             "name": "azjezz/psl",


### PR DESCRIPTION
  Some older versions seems to have issues with eachother leading to:

 ```
 Fatal error: Uncaught Error: Call to undefined method Pipeline\Standard::select() in vendor/sanmai/di-container/src/Container.php:244
 ```